### PR TITLE
feat: add chore variant to specify types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build clean dev version demo $(TARGETS)
 
 BINARY_NAME := convit
-VERSION := 0.5.1
+VERSION := 0.6.0
 BUILD_DIR := bin
 
 TARGETS := darwin-arm64 darwin-amd64 linux-arm64 linux-amd64

--- a/convit.go
+++ b/convit.go
@@ -37,6 +37,7 @@ var CommitTypes = []CommitType{
 	{Type: "chore", SubType: "release", Description: "Release / Version tags"},
 	{Type: "chore", SubType: "deps", Description: "Add, remove or update dependencies"},
 	{Type: "chore", SubType: "dev-deps", Description: "Add, remove or update development dependencies"},
+	{Type: "chore", SubType: "types", Description: "Add or update types."},
 }
 
 type Convit struct{}


### PR DESCRIPTION
### Description
This PR updates the version number and adds a new commit type for type-related changes.

### Added
- New commit type `chore(types)` for adding or updating types

### Changed
- Version number updated from 0.5.1 to 0.6.0 in the Makefile

### Fixed

### Removed